### PR TITLE
Add chromedriver and geckodriver

### DIFF
--- a/mac
+++ b/mac
@@ -145,6 +145,8 @@ brew_install_or_upgrade 'imagemagick'
 brew_install_or_upgrade 'qt'
 brew_install_or_upgrade 'hub'
 brew_install_or_upgrade 'node'
+brew_install_or_upgrade 'chromedriver'
+brew_install_or_upgrade 'geckodriver'
 
 brew_install_or_upgrade 'openssl'
 brew unlink openssl && brew link openssl --force


### PR DESCRIPTION
From the new version of Rails Template, we going to use Chrome (sometimes can be Firefox), we have to install the `chromedriver` and `geckodriver` on the local machine, I think it good it if have 2 of that on the laptop script