### PR TITLE
Add gpg2 and update Heroku and NVM.

### DIFF
--- a/mac
+++ b/mac
@@ -123,12 +123,13 @@ brew "the_silver_searcher"
 brew "tmux"
 brew "vim"
 brew "watchman"
+brew "gpg2"
 brew "zsh"
 fancy_echo "Extending zsh with oh-my-zsh ..."
 sh -c "$(curl -fsSL https://raw.githubusercontent.com/robbyrussell/oh-my-zsh/master/tools/install.sh)"
 
 # Heroku
-brew "heroku"
+brew "heroku/brew/heroku"
 
 # GitHub
 brew "hub"
@@ -179,7 +180,7 @@ bundle config --global jobs $((number_of_cores - 1))
 
 # Install Node
 
-curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.8/install.sh | bash
+curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.11/install.sh | bash
 
 if [ -f "$HOME/.laptop.local" ]; then
   fancy_echo "Running your customizations from ~/.laptop.local ..."


### PR DESCRIPTION
From #6 
- Add `gpg2` support.
- Update Heroku CLI brew package according to https://devcenter.heroku.com/articles/heroku-cli.
- Update NVM version. 