### PR TITLE
Fix errors: brewfile, gpg2, heroku, rvm, nvm, and add finish echo

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,10 @@ Install
 
 Download, review, then execute the script:
 
-```sh
+```bash
 curl --remote-name https://raw.githubusercontent.com/nimbl3/laptop/master/mac
 less mac
-sh mac 2>&1 | tee ~/laptop.log
+bash mac 2>&1 | tee ~/laptop.log
 ```
 
 Debugging

--- a/mac
+++ b/mac
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Welcome to the Nimbl3 laptop script!
 # Be prepared to turn your laptop (or desktop, no haters here)
@@ -113,6 +113,7 @@ brew bundle --file=- <<EOF
 tap "homebrew/services"
 tap "universal-ctags/universal-ctags"
 tap "caskroom/cask"
+tap "heroku/brew"
 
 # Unix
 brew "universal-ctags", args: ["HEAD"]
@@ -125,8 +126,6 @@ brew "vim"
 brew "watchman"
 brew "gpg2"
 brew "zsh"
-fancy_echo "Extending zsh with oh-my-zsh ..."
-sh -c "$(curl -fsSL https://raw.githubusercontent.com/robbyrussell/oh-my-zsh/master/tools/install.sh)"
 
 # Heroku
 brew "heroku/brew/heroku"
@@ -151,10 +150,26 @@ cask "docker"
 brew "postgres"
 brew "redis"
 
-# Basics
-cask "google-chrome"
-cask "slack"
 EOF
+
+# Basics Apps
+
+if [ ! -d "/Applications/Google Chrome.app" ]; then
+  fancy_echo "Installing Google Chrome.."
+  brew cask install google-chrome
+  fancy_echo "Google Chrome installed."
+fi
+
+if [ ! -d "/Applications/Slack.app" ]; then
+  fancy_echo "Installing Slack.."
+  brew cask install slack
+  fancy_echo "Slack installed."
+fi
+
+brew link --overwrite gnupg
+
+fancy_echo "Extending zsh with oh-my-zsh ..."
+sh -c "$(curl -fsSL https://raw.githubusercontent.com/robbyrussell/oh-my-zsh/master/tools/install.sh)"
 
 if brew list | grep --silent "qt@5.5"; then
   fancy_echo "Symlink qmake binary to /usr/local/bin for Capybara Webkit..."
@@ -171,6 +186,7 @@ brew link --force heroku
 curl -sSL https://rvm.io/mpapis.asc | gpg2 --import
 curl -L https://get.rvm.io | bash -s stable
 
+source ~/.rvm/scripts/rvm
 rvm use ruby --install --default
 
 gem update --system
@@ -182,8 +198,18 @@ bundle config --global jobs $((number_of_cores - 1))
 
 curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.11/install.sh | bash
 
+if ! command -v nvm; then
+  fancy_echo "Adding nvm to zshrc automatically..."
+  append_to_zshrc '# nvm path
+export NVM_DIR="$HOME/.nvm"
+[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
+[ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion'
+fi
+
 if [ -f "$HOME/.laptop.local" ]; then
   fancy_echo "Running your customizations from ~/.laptop.local ..."
   # shellcheck disable=SC1090
   . "$HOME/.laptop.local"
 fi
+
+fancy_echo "Installation successful. Please open a new terminal window to continue"


### PR DESCRIPTION
So while installing I got several errors and I tried to address all the errors. I also attach logs for some error. This is my first time modifying shell script so yeaa. There's no more error when running on my machine, but this needs to be tested on a brand new machine. I also didn't create the issue first, if it's better to break this PR into several smaller ones just let me know 😃 

### 1. Brewfile error
This one is caused because of lines:
```bash
fancy_echo "Extending zsh with oh-my-zsh ..."
sh -c "$(curl -fsSL https://raw.githubusercontent.com/robbyrussell/oh-my-zsh/master/tools/install.sh)"
```
Are between the brew bundle command:
```bash
brew bundle --file=- << EOF
tap "homebrew/services"
tap "universal-ctags/universal-ctags"
...
brew "redis"
EOF
```
Running brew bundle is like running `npm install`, so it loads the configuration from Brewfile and install them. But in this case we supply the Brewfile using the `<<`. Brew bundle normally cannot run the usual shell command. So, moving the oh-my-zsh installing line to after brew bundle command can solve this issue.

[1.brewfileerror.log](https://github.com/nimbl3/laptop/files/2067548/1.brewfileerror.log)

### 2. Heroku cask error:
Before the brew bundle can run
```bash
brew "heroku/brew/heroku"
```
it needs to run
```bash
tap "heroku/brew"
```

### 3. RVM restart error #7 :
After installing RVM, we need to run
```bash
source ~/.rvm/scripts/rvm
```
so the RVM commands are available to current session. To automatically do this so the following script can working, the `source ~/.rvm/scripts/rvm` was added after installing RVM. Unfortunately, `source` is not available when running with `sh` on MacOSX, but available when running via with `bash`. So the running command is changed from
```bash
sh mac 2>&1 | tee ~/laptop.log
```
into
```bash
bash mac 2>&1 | tee ~/laptop.log
```
What I read so far is there's not much difference between `bash` and `sh` so I think this won't cause much problems.

[3.rvmerror.log](https://github.com/nimbl3/laptop/files/2067547/3.rvmerror.log)

### 4. gpg2 brew link error:
After installing brew gpg2, the following errors come up:
```bash
Error: The `brew link` step did not complete successfully
The formula built, but is not symlinked into /usr/local
Could not symlink bin/gpg
Target /usr/local/bin/gpg
already exists. You may want to remove it:
  rm '/usr/local/bin/gpg'

To force the link and overwrite all conflicting files:
  brew link --overwrite gnupg

To list all files that would be deleted:
  brew link --overwrite --dry-run gnupg
```
So the `brew link --overwrite gnupg` is added to the script file to solve the issue

[4.gpg2failed.log](https://github.com/nimbl3/laptop/files/2067546/4.gpg2failed.log)

 ### 5. Ruby error [WIP]:
After installing Ruby, there's error:
```bash
se: command not found
```
But when I try the script again somehow it doesn't pop up anymore. Needs to test this one on a brand new machine.
[5.rubyerror.log](https://github.com/nimbl3/laptop/files/2067545/5.rubyerror.log)

### 6. NVM doesn't add pathfile to `~/.zshrc`:
Even though on [its website](https://github.com/creationix/nvm#install-script) it says the script add source line to `~/.zshrc` but when I try the script it only adds to `~/.bashrc`. So a code is added to add the source for nvm to `~/.zshrc`:
```bash
if ! command -v nvm; then
  fancy_echo "Adding nvm to zshrc automatically..."
  append_to_zshrc '# nvm path
export NVM_DIR="$HOME/.nvm"
[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
[ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion'
fi
```

### 7. Error when Google Chrome is installed:
If Google Chrome is installed manually (e.g. downloading from their site) like what I did, and this code is run:
```bash
cask "google-chrome"
```
It caused error and the script won't continue to run the other command. So conditional code is installed to check whether Google Chrome is installed before running `cask "google-chrome"`.

