### PR TITLE
Update script to run properly, zsh configuration is optional

### DIFF
--- a/mac
+++ b/mac
@@ -119,8 +119,7 @@ gem_install_or_update() {
 
 install_rvm() {
   fancy_echo "Installing RVM"
-  brew install gpg2
-  gpg2 --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
+  gpg --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
   curl -L https://get.rvm.io | bash -s stable
 
   source "$HOME/.rvm/scripts/rvm"
@@ -191,6 +190,7 @@ append_general_dependencies() {
     brew "universal-ctags", args: ["HEAD"]
     brew "git"
     brew "openssl"
+    brew "gpg2"
     brew "zsh"
 
     # GitHub extensions

--- a/mac
+++ b/mac
@@ -59,6 +59,8 @@ config_zsh() {
   if [[ ! $response =~ (n|no|N) ]];then
     sudo chsh -s $(which zsh)
 
+    append_to_zshrc 'ZSH_DISABLE_COMPFIX=true'
+
     fancy_echo "Installing Oh my Zsh"
     sh -c "$(curl -fsSL https://raw.githubusercontent.com/robbyrussell/oh-my-zsh/master/tools/install.sh)"
 

--- a/mac
+++ b/mac
@@ -55,7 +55,8 @@ append_to_zshrc() {
 
 config_zsh() {
   read -r -p "Do you want to install Zsh's extensions? [Y|n] " response
-  if [[ $response =~ (n|no|N) ]];then
+
+  if [[ ! $response =~ (n|no|N) ]];then
     sudo chsh -s $(which zsh)
 
     fancy_echo "Installing Oh my Zsh"
@@ -139,12 +140,9 @@ install_homebrew() {
 }
 
 setup_postgres() {
-  alias pg-start="pg_ctl -D /usr/local/var/postgres start"
-  alias pg-stop="pg_ctl -D /usr/local/var/postgres stop"
-  alias pg-restart="pg_ctl -D /usr/local/var/postgres restart"
-  pg-start
+  pg_ctl -D /usr/local/var/postgres start
   /usr/local/opt/postgres/bin/createuser -s postgres
-  pg-stop
+  pg_ctl -D /usr/local/var/postgres stop
 }
 
 append_general_dependencies() {
@@ -299,6 +297,7 @@ install() {
 # Run
 install
 
-fancy_echo "Installation successful. Please open a new terminal window to continue"
-
+# Zsh extensions
 config_zsh
+
+fancy_echo "Installation successful"

--- a/mac
+++ b/mac
@@ -119,7 +119,8 @@ gem_install_or_update() {
 
 install_rvm() {
   fancy_echo "Installing RVM"
-  curl -sSL https://rvm.io/mpapis.asc | gpg2 --import
+  brew install gpg2
+  gpg2 --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
   curl -L https://get.rvm.io | bash -s stable
 
   source "$HOME/.rvm/scripts/rvm"
@@ -190,7 +191,6 @@ append_general_dependencies() {
     brew "universal-ctags", args: ["HEAD"]
     brew "git"
     brew "openssl"
-    brew "gpg2"
     brew "zsh"
 
     # GitHub extensions

--- a/mac
+++ b/mac
@@ -119,7 +119,7 @@ gem_install_or_update() {
 
 install_rvm() {
   fancy_echo "Installing RVM"
-  gpg --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
+  curl -sSL https://rvm.io/mpapis.asc | gpg --import
   curl -L https://get.rvm.io | bash -s stable
 
   source "$HOME/.rvm/scripts/rvm"

--- a/mac
+++ b/mac
@@ -106,7 +106,13 @@ gem_install_or_update() {
 
 install_rvm() {
   fancy_echo "Installing RVM"
-  curl -sSL https://rvm.io/mpapis.asc | gpg --import
+
+  curl -sSL https://rvm.io/mpapis.asc | gpg --import -
+  curl -sSL https://rvm.io/pkuczynski.asc | gpg --import -
+
+  echo 409B6B1796C275462A1703113804BB82D39DC0E3:6: | gpg --import-ownertrust
+  echo 7D2BAF1CF37B13E2069D6956105BD0E739499BDB:6: | gpg --import-ownertrust
+
   curl -L https://get.rvm.io | bash -s stable
 
   source "$HOME/.rvm/scripts/rvm"
@@ -174,7 +180,7 @@ append_general_dependencies() {
     brew "universal-ctags", args: ["HEAD"]
     brew "git"
     brew "openssl"
-    brew "gpg2"
+    brew "gpg"
     brew "zsh"
 
     # GitHub extensions

--- a/mac
+++ b/mac
@@ -53,45 +53,29 @@ append_to_zshrc() {
   fi
 }
 
-update_shell() {
-  local shell_path;
-  shell_path="$(which zsh)"
-
-  fancy_echo "Changing your shell to zsh ..."
-  if ! grep "$shell_path" /etc/shells > /dev/null 2>&1 ; then
-    fancy_echo "Adding '$shell_path' to /etc/shells"
-    sudo sh -c "echo $shell_path >> /etc/shells"
-  fi
-  sudo chsh -s "$shell_path" "$USER"
-}
-
 config_zsh() {
-  case "$SHELL" in
-    */zsh)
-      if [ "$(which zsh)" != '/usr/local/bin/zsh' ] ; then
-        update_shell
-      fi
-      ;;
-    *)
-      update_shell
-      ;;
-  esac
+  read -r -p "Do you want to install Zsh's extensions? [Y|n] " response
+  if [[ $response =~ (n|no|N) ]];then
+    sudo chsh -s $(which zsh)
 
-  # Config Oh my ZSH
-  sh -c "$(curl -fsSL https://raw.githubusercontent.com/robbyrussell/oh-my-zsh/master/tools/install.sh)"
-  if [ ! -d ~/.zsh-defer ]; then
-    git clone https://github.com/romkatv/zsh-defer.git ~/.zsh-defer
+    fancy_echo "Installing Oh my Zsh"
+    sh -c "$(curl -fsSL https://raw.githubusercontent.com/robbyrussell/oh-my-zsh/master/tools/install.sh)"
+
+    if [ ! -d ~/.zsh-defer ]; then
+      git clone https://github.com/romkatv/zsh-defer.git ~/.zsh-defer
+    fi
+    if [ ! -d ~/.zsh/zsh-autosuggestions ]; then
+      git clone https://github.com/zsh-users/zsh-autosuggestions ~/.zsh/zsh-autosuggestions
+    fi
+    if [ ! -d ~/.zsh/zsh-syntax-highlighting ]; then
+      git clone https://github.com/zsh-users/zsh-syntax-highlighting.git ~/.zsh/zsh-syntax-highlighting
+    fi
+    if [ ! -d ~/.oh-my-zsh/custom/plugins/zsh-completions ]; then
+      git clone https://github.com/zsh-users/zsh-completions ~/.oh-my-zsh/custom/plugins/zsh-completions
+    fi
+
+    fancy_echo "Configured Zsh"
   fi
-  if [ ! -d ~/.zsh/zsh-autosuggestions ]; then
-    git clone https://github.com/zsh-users/zsh-autosuggestions ~/.zsh/zsh-autosuggestions
-  fi
-  if [ ! -d ~/.zsh/zsh-syntax-highlighting ]; then
-    git clone https://github.com/zsh-users/zsh-syntax-highlighting.git ~/.zsh/zsh-syntax-highlighting
-  fi
-  if [ ! -d ~/.oh-my-zsh/custom/plugins/zsh-completions ]; then
-    git clone https://github.com/zsh-users/zsh-completions ~/.oh-my-zsh/custom/plugins/zsh-completions
-  fi
-  success "Configured zsh"
 }
 
 install_nvm() {
@@ -270,7 +254,6 @@ install_dependencies() {
 
   install_rvm
   install_nvm
-  config_zsh
   setup_postgres
 
   fancy_echo "Installed dependencies"
@@ -317,3 +300,5 @@ install() {
 install
 
 fancy_echo "Installation successful. Please open a new terminal window to continue"
+
+config_zsh


### PR DESCRIPTION
## What happened

- Sometimes we get random error from `gpg import` command, so I made the changes to avoid it
- Some people don't use zsh, so I changed it to optional
 
## Insight

- Change from `gpg2` to `gpg`
- Config `zsh` at the end of the script to avoid switching shell
- Config postgres without setting aliases 
- Add RVM backup keys
- I tried on the new laptop (MBP 2015) but it didn't find the gpg2 command, so switch to use `gpg` instead
- Sometimes, the link `https://rvm.io/mpapis.asc` doesn't work properly, so I add another link to verify RVM
- When installing oh-my-zsh, it might be switch the shell and cause some errors, so I put the `config_zsh` command at the end
 
## Proof Of Work

- The script should work properly
- Tested on Mike's laptop