### PR TITLE
Update Github CLI formula

### DIFF
--- a/mac
+++ b/mac
@@ -184,7 +184,7 @@ append_general_dependencies() {
     brew "zsh"
 
     # GitHub extensions
-    brew "github/gh/gh"
+    brew "gh"
     cask "github" unless File.directory?("/Applications/GitHub Desktop.app")
     brew "git-lfs"
 


### PR DESCRIPTION
## What happened

Github has just released GitHub CLI 1.0 hence we should update to the newer version
 
## Insight

Just change the formula from `github/gh/gh` to `gh`
 
## Proof Of Work

N/A
