### PR TITLE
Moved nvm config to separate function and call after zsh installation

### DIFF
--- a/mac
+++ b/mac
@@ -87,6 +87,8 @@ install_nvm() {
   fancy_echo "Installing NVM"
   curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.11/install.sh | bash
 
+  zsh_config_nvm
+  
   fancy_echo "Installed NVM"
 }
 

--- a/mac
+++ b/mac
@@ -77,6 +77,8 @@ config_zsh() {
       git clone https://github.com/zsh-users/zsh-completions ~/.oh-my-zsh/custom/plugins/zsh-completions
     fi
 
+    zsh_config_nvm
+
     fancy_echo "Configured Zsh"
   fi
 }
@@ -85,15 +87,17 @@ install_nvm() {
   fancy_echo "Installing NVM"
   curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.11/install.sh | bash
 
-  if ! command -v nvm; then
+  fancy_echo "Installed NVM"
+}
+
+zsh_config_nvm() {
+    if ! command -v nvm; then
     fancy_echo "Adding nvm to zshrc automatically..."
     append_to_zshrc '# nvm path
 export NVM_DIR="$HOME/.nvm"
 [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
 [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion'
   fi
-
-  fancy_echo "Installed NVM"
 }
 
 gem_install_or_update() {


### PR DESCRIPTION

## What happened

When running the laptop script, if you select web dependencies and zsh extensions, the nvm extension does not get appended to the .zshrc file. My proposal is:

1. Move append nvm to separate function
2. Call function in initial nvm installation
3. Also call function after `oh my zsh` is installed (as installation seems to clear the .zshrc file)
 

## Insight

I initially tried running just the nvm function to see if the issue might be the function itself. Function works fine.

Then I tried uninstalling zsh and re-running the script from the nvm mark, `oh my zsh` installation does indeed reset the .zshrc file.

So I tried running the function after the installation, which works and solves the problem.

## Proof Of Work

Testing shows that new script is properly adding nvm to .zshrc file. 
<img width="857" alt="Screen Shot 2020-11-18 at 9 38 46 AM" src="https://user-images.githubusercontent.com/29936423/99477251-b55b1800-2984-11eb-917c-d2c1ab242a99.png">
