### PR TITLE
Fix Homebrew installer

### DIFF
--- a/mac
+++ b/mac
@@ -134,8 +134,8 @@ install_rvm() {
 install_homebrew() {
   if ! command -v brew >/dev/null; then
     fancy_echo "Installing Homebrew ..."
-      curl -fsS \
-        'https://raw.githubusercontent.com/Homebrew/install/master/install' | ruby
+      /bin/bash -c \
+          "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
 
       append_to_zshrc '# recommended by brew doctor'
 


### PR DESCRIPTION
## What happened

Update the command to install Homebrew.
 
## Insight

The Ruby-based installer has been deprecated therefore the laptop script currently fails:

<img width="569" alt="Screen Shot 2564-02-02 at 16 13 13" src="https://user-images.githubusercontent.com/696529/106578850-91b27180-6572-11eb-8647-048b06f00aa3.png">

From the homepage of [Homebrew](https://brew.sh/):

![image](https://user-images.githubusercontent.com/696529/106579856-c541cb80-6573-11eb-8d61-dda60d52c1a7.png)
 
## Proof Of Work

| Before 😿 | After 🎉 |
|-|-|
| <img width="754" alt="Screen Shot 2564-02-02 at 16 25 04" src="https://user-images.githubusercontent.com/696529/106579528-62e8cb00-6573-11eb-9041-9e9f09d4779e.png"> | <img width="789" alt="Screen Shot 2564-02-02 at 16 25 20" src="https://user-images.githubusercontent.com/696529/106579571-7136e700-6573-11eb-98fb-6b83c0412cac.png"> |