### PR TITLE
Make `asdf` the default version manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 *.swp
 .idea/
+
+laptop.log

--- a/mac
+++ b/mac
@@ -144,6 +144,10 @@ install_asdf() {
   fancy_echo "Configuring asdf version manager ..."
   if [ ! -d "$HOME/.asdf" ]; then
     brew install asdf
+
+    # shellcheck disable=SC2016
+    append_to_zshrc 'export PATH=~/.asdf/shims:$PATH"'
+
     append_to_zshrc "source $(brew --prefix asdf)/asdf.sh" 1
   fi
 }

--- a/mac
+++ b/mac
@@ -161,8 +161,14 @@ add_or_update_asdf_plugin() {
 
 install_asdf_language() {
   local language="$1"
+  local regex_pattern="$2"
   local version
-  version="$(asdf list-all "$language" | grep -v "[a-z]" | tail -1)"
+
+  if [ -z "$regex_pattern" ]; then
+    regex_pattern="^\d+.\d+.?\d?$"
+  fi
+
+  version="$(asdf list-all "$language" | grep -E "$regex_pattern" | tail -1)"
 
   if ! asdf list "$language" | grep -Fq "$version"; then
     asdf install "$language" "$version"
@@ -206,7 +212,7 @@ install_asdf_elixir() {
   add_or_update_asdf_plugin "elixir" "https://github.com/asdf-vm/asdf-elixir.git"
 
   fancy_echo "Installing latest Elixir ..."
-  install_asdf_language "elixir"
+  install_asdf_language "elixir" "^\d+.\d+.?\d+?-otp-\d+$"
 }
 
 setup_postgres() {

--- a/mac
+++ b/mac
@@ -104,30 +104,9 @@ config_zsh() {
     # shellcheck disable=SC2016
     append_to_zshrc 'export PATH="$HOME/.bin:$PATH"'
 
-    zsh_config_rvm
-    zsh_config_nvm
     zsh_config_homebrew
 
     fancy_echo "Configured Zsh"
-  fi
-}
-
-install_nvm() {
-  fancy_echo "Installing NVM"
-  curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.11/install.sh | bash
-
-  zsh_config_nvm
-  
-  fancy_echo "Installed NVM"
-}
-
-zsh_config_nvm() {
-    if ! command -v nvm; then
-    fancy_echo "Adding nvm to zshrc automatically..."
-    append_to_zshrc '# nvm path
-export NVM_DIR="$HOME/.nvm"
-[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
-[ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion'
   fi
 }
 
@@ -137,33 +116,6 @@ gem_install_or_update() {
   else
     gem install "$@"
   fi
-}
-
-install_rvm() {
-  fancy_echo "Installing RVM"
-
-  curl -sSL https://rvm.io/mpapis.asc | gpg --import -
-  curl -sSL https://rvm.io/pkuczynski.asc | gpg --import -
-
-  echo 409B6B1796C275462A1703113804BB82D39DC0E3:6: | gpg --import-ownertrust
-  echo 7D2BAF1CF37B13E2069D6956105BD0E739499BDB:6: | gpg --import-ownertrust
-
-  curl -L https://get.rvm.io | bash -s stable
-
-  source "$HOME/.rvm/scripts/rvm"
-  rvm use ruby --install --default
-
-  gem update --system
-  gem_install_or_update "bundler"
-  number_of_cores=$(sysctl -n hw.ncpu)
-  bundle config --global jobs $((number_of_cores - 1))
-  fancy_echo "Installed RVM"
-}
-
-zsh_config_rvm() {
-  fancy_echo "Adding rvm to zshrc automatically..."
-  append_to_zshrc '# Add RVM to PATH for scripting. Make sure this is the last PATH variable change.
-export PATH="$PATH:$HOME/.rvm/bin"'
 }
 
 install_homebrew() {
@@ -186,6 +138,57 @@ install_homebrew() {
 zsh_config_homebrew() {
   fancy_echo "Adding brew to zshrc automatically..."
   append_to_zshrc "eval \"\$($HOMEBREW_PREFIX/bin/brew shellenv)\""
+}
+
+install_asdf() {
+  fancy_echo "Configuring asdf version manager ..."
+  if [ ! -d "$HOME/.asdf" ]; then
+    brew install asdf
+    append_to_zshrc "source $(brew --prefix asdf)/asdf.sh" 1
+  fi
+}
+
+add_or_update_asdf_plugin() {
+  local name="$1"
+  local url="$2"
+
+  if ! asdf plugin-list | grep -Fq "$name"; then
+    asdf plugin-add "$name" "$url"
+  else
+    asdf plugin-update "$name"
+  fi
+}
+
+install_asdf_language() {
+  local language="$1"
+  local version
+  version="$(asdf list-all "$language" | grep -v "[a-z]" | tail -1)"
+
+  if ! asdf list "$language" | grep -Fq "$version"; then
+    asdf install "$language" "$version"
+    asdf global "$language" "$version"
+  fi
+}
+
+install_asdf_ruby() {
+  # shellcheck disable=SC1090
+  . "$(brew --prefix asdf)/asdf.sh"
+  add_or_update_asdf_plugin "ruby" "https://github.com/asdf-vm/asdf-ruby.git"
+
+  fancy_echo "Installing latest Ruby ..."
+  install_asdf_language "ruby"
+  gem update --system
+  number_of_cores=$(sysctl -n hw.ncpu)
+  bundle config --global jobs $((number_of_cores - 1))
+}
+
+install_asdf_nodejs() {
+  # shellcheck disable=SC1090
+  . "$(brew --prefix asdf)/asdf.sh"
+  add_or_update_asdf_plugin "nodejs" "https://github.com/asdf-vm/asdf-nodejs.git"
+
+  fancy_echo "Installing latest Node ..."
+  install_asdf_language "nodejs"
 }
 
 setup_postgres() {
@@ -260,7 +263,6 @@ append_web_dependencies() {
 
     # Languages
     brew "go"
-    brew "elixir"
 
     # Devops
     cask "docker"
@@ -311,9 +313,7 @@ install_dependencies() {
   fancy_echo "Installing dependencies"
   brew bundle --global --verbose --no-upgrade
 
-  install_rvm
-  install_nvm
-  setup_postgres
+  #setup_postgres
 
   fancy_echo "Installed dependencies"
 }
@@ -349,6 +349,12 @@ install() {
   fi
 
   install_dependencies
+
+  if [[ $web_dep =~ (y|yes|Y) ]];then
+    install_asdf
+    install_asdf_ruby
+    install_asdf_nodejs
+  fi
 
   install_laptop_local
 

--- a/mac
+++ b/mac
@@ -331,7 +331,7 @@ install_dependencies() {
   fancy_echo "Installing dependencies"
   brew bundle --global --verbose --no-upgrade
 
-  #setup_postgres
+  setup_postgres
 
   fancy_echo "Installed dependencies"
 }

--- a/mac
+++ b/mac
@@ -191,6 +191,24 @@ install_asdf_nodejs() {
   install_asdf_language "nodejs"
 }
 
+install_asdf_erlang() {
+  # shellcheck disable=SC1090
+  . "$(brew --prefix asdf)/asdf.sh"
+  add_or_update_asdf_plugin "erlang" "https://github.com/asdf-vm/asdf-erlang.git"
+
+  fancy_echo "Installing latest Erlang ..."
+  install_asdf_language "erlang"
+}
+
+install_asdf_elixir() {
+  # shellcheck disable=SC1090
+  . "$(brew --prefix asdf)/asdf.sh"
+  add_or_update_asdf_plugin "elixir" "https://github.com/asdf-vm/asdf-elixir.git"
+
+  fancy_echo "Installing latest Elixir ..."
+  install_asdf_language "elixir"
+}
+
 setup_postgres() {
   pg_ctl -D "$HOMEBREW_PREFIX/var/postgres" start
   "$HOMEBREW_PREFIX/opt/postgres/bin/createuser" -s postgres
@@ -354,6 +372,8 @@ install() {
     install_asdf
     install_asdf_ruby
     install_asdf_nodejs
+    install_asdf_erlang
+    install_asdf_elixir
   fi
 
   install_laptop_local


### PR DESCRIPTION
## What Happened 

- Replace RVM with `asdf`
- Replace NVM with `asdf`
- Add Erlang installation via `asdf`
- Add Install Elixir via `asdf`

Resolves #33, Fix #25 

## Insights

Most of the code for `asdf` comes from the original Laptop script but I improved the way the latest version is computed following @andyduong1920['s comment ](https://github.com/nimblehq/laptop/pull/34#discussion_r884395463) 💪 

## Proof of Work

Tested on Intel:

![image](https://user-images.githubusercontent.com/696529/170650393-ed3f9ace-a94a-489f-ac97-3ec7f7fb6546.png)

![image](https://user-images.githubusercontent.com/696529/170650305-3b1c2c51-c788-4803-aae9-c7e3eca216d8.png)

Tested on M1:

<img width="731" alt="image" src="https://user-images.githubusercontent.com/696529/170665005-baee4bcb-c175-46b1-9cab-1c4c6cb886c3.png">

<img width="829" alt="image" src="https://user-images.githubusercontent.com/696529/170664848-753d427f-6549-4a01-bb8a-7ebc07675f03.png">