### PR TITLE
Fix and improvements for postgres and asdf 

### DIFF
--- a/mac
+++ b/mac
@@ -106,6 +106,9 @@ config_zsh() {
 
     zsh_config_homebrew
 
+    # shellcheck disable=SC2016
+    append_to_zshrc 'export PATH="$HOME/.asdf/shims:$PATH"'
+
     fancy_echo "Configured Zsh"
   fi
 }
@@ -146,9 +149,9 @@ install_asdf() {
     brew install asdf
 
     # shellcheck disable=SC2016
-    append_to_zshrc 'export PATH=~/.asdf/shims:$PATH"'
+    append_to_zshrc 'export PATH="$HOME/.asdf/shims:$PATH"'
 
-    append_to_zshrc "source $(brew --prefix asdf)/asdf.sh" 1
+    append_to_zshrc "source $(brew --prefix asdf)/libexec/asdf.sh" 1
   fi
 }
 
@@ -182,7 +185,7 @@ install_asdf_language() {
 
 install_asdf_ruby() {
   # shellcheck disable=SC1090
-  . "$(brew --prefix asdf)/asdf.sh"
+  . "$(brew --prefix asdf)/libexec/asdf.sh"
   add_or_update_asdf_plugin "ruby" "https://github.com/asdf-vm/asdf-ruby.git"
 
   fancy_echo "Installing latest Ruby ..."
@@ -194,7 +197,7 @@ install_asdf_ruby() {
 
 install_asdf_nodejs() {
   # shellcheck disable=SC1090
-  . "$(brew --prefix asdf)/asdf.sh"
+  . "$(brew --prefix asdf)/libexec/asdf.sh"
   add_or_update_asdf_plugin "nodejs" "https://github.com/asdf-vm/asdf-nodejs.git"
 
   fancy_echo "Installing latest Node ..."
@@ -203,7 +206,7 @@ install_asdf_nodejs() {
 
 install_asdf_erlang() {
   # shellcheck disable=SC1090
-  . "$(brew --prefix asdf)/asdf.sh"
+  . "$(brew --prefix asdf)/libexec/asdf.sh"
   add_or_update_asdf_plugin "erlang" "https://github.com/asdf-vm/asdf-erlang.git"
 
   fancy_echo "Installing latest Erlang ..."
@@ -212,7 +215,7 @@ install_asdf_erlang() {
 
 install_asdf_elixir() {
   # shellcheck disable=SC1090
-  . "$(brew --prefix asdf)/asdf.sh"
+  . "$(brew --prefix asdf)/libexec/asdf.sh"
   add_or_update_asdf_plugin "elixir" "https://github.com/asdf-vm/asdf-elixir.git"
 
   fancy_echo "Installing latest Elixir ..."
@@ -220,9 +223,9 @@ install_asdf_elixir() {
 }
 
 setup_postgres() {
-  pg_ctl -D "$HOMEBREW_PREFIX/var/postgres" start
-  "$HOMEBREW_PREFIX/opt/postgres/bin/createuser" -s postgres
-  pg_ctl -D "$HOMEBREW_PREFIX/var/postgres" stop
+  pg_ctl -D "$HOMEBREW_PREFIX/var/postgresql@14" start
+  "$HOMEBREW_PREFIX/opt/postgresql@14/bin/createuser" -s postgres
+  pg_ctl -D "$HOMEBREW_PREFIX/var/postgresql@14" stop
 }
 
 append_general_dependencies() {
@@ -301,7 +304,7 @@ append_web_dependencies() {
     brew "imagemagick"
 
     # Databases
-    brew "postgres"
+    brew "postgresql@14" unless File.directory?("/Applications/Postgres.app")
 
     # Others
     brew "yarn"
@@ -341,7 +344,11 @@ install_dependencies() {
   fancy_echo "Installing dependencies"
   brew bundle --global --verbose --no-upgrade
 
-  setup_postgres
+  if [[ "$(which postgres)" =~ "postgres not found" ]] && [[ ! -d "/Applications/Postgres.app" ]]; then
+    setup_postgres
+  else
+    fancy_echo "postgres already installed, skipping setup"
+  fi
 
   fancy_echo "Installed dependencies"
 }

--- a/mac
+++ b/mac
@@ -107,7 +107,7 @@ config_zsh() {
     zsh_config_homebrew
 
     # shellcheck disable=SC2016
-    append_to_zshrc 'export PATH="$HOME/.asdf/shims:$PATH"'
+    append_to_zshrc 'export PATH=~/.asdf/shims:$PATH'
 
     fancy_echo "Configured Zsh"
   fi
@@ -149,7 +149,7 @@ install_asdf() {
     brew install asdf
 
     # shellcheck disable=SC2016
-    append_to_zshrc 'export PATH="$HOME/.asdf/shims:$PATH"'
+    append_to_zshrc 'export PATH=~/.asdf/shims:$PATH'
 
     append_to_zshrc "source $(brew --prefix asdf)/libexec/asdf.sh" 1
   fi
@@ -304,7 +304,7 @@ append_web_dependencies() {
     brew "imagemagick"
 
     # Databases
-    brew "postgresql@14" unless File.directory?("/Applications/Postgres.app")
+    brew "postgresql@14"
 
     # Others
     brew "yarn"
@@ -344,7 +344,7 @@ install_dependencies() {
   fancy_echo "Installing dependencies"
   brew bundle --global --verbose --no-upgrade
 
-  if [[ "$(which postgres)" =~ "postgres not found" ]] && [[ ! -d "/Applications/Postgres.app" ]]; then
+  if [[ "$(which postgres)" =~ "postgres not found" ]]; then
     setup_postgres
   else
     fancy_echo "postgres already installed, skipping setup"


### PR DESCRIPTION
Close #37

## What happened

- Fixed postgres installation by changing the brew package from `postgres` to `postgresql@<version>`
- asdf:
   -  `asdf.sh` is situated inside an additional directory `/libexec` during install so the paths have been updated
   - Fixed existing `shims` export in .zshrc as it had a trailing `"` so the commands wouldn't be available (I actually added an opening `"` with `$HOME` instead of keeping existing `~` and deleting the trailing comma. I think this change is same.
   - Included the above shims export to .zshrc if the `oh-my-zsh` add-on was chosen at the end (because it overwrites it). If this isn't added then the same errors "command not found" would re-occur again.
- Added a check for existing postgres on the system prior to installing the postgresql brew package `and` the function responsible for starting/stopping postgres service and creating the new database user.
 
## Insight

1. The explicit version of `postgresql` seems to be required for `brew`. The following error is shown if just changed to `postgresql` without version:

```
Warning: No available formula with the name "postgresql". Did you mean postgresql@13, postgresql@12, postgresql@11, postgresql@15, postgresql@10, postgresql@14, postgresql@9.5, postgresql@9.4, postgrest or qt-postgresql?
postgresql breaks existing databases on upgrade without human intervention.
```

So have chosen `14` which would be `14.7` which is only a few months old (didn't want to try 15 but willing to change).

2. For the postgres existing installation pre-check I have included the location of `/Applications/Postgres.app` (https://postgresapp.com) in addition to brew in case a user has an existing installation by this method instead (willing to change)
 
**Potential improvements**
- Make a global variable for postgresql version number
- Change existing shell command `which` to a folder check depending on if M1 or otherwise for existing postgres check.

## Proof Of Work

Success output when running script - https://pastebin.com/N8kVaTBE
