### PR TITLE
[#48] Add Xcodes App

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,12 +142,14 @@ Plugins for asdf:
 - [Proxyman] enables developers to observe and manipulate HTTP/HTTPS requests
 - [Atlassian SourceTree] a free Git client for Mac
 - [XCode] iOS IDE
+- [Xcodes] a GUI app that helps you manage multiple versions of Xcode
 
 [cocoapods]: https://cocoapods.org/
 [figma]: https://www.figma.com/
 [proxyman]: https://proxyman.io/
 [atlassian sourcetree]: https://www.sourcetreeapp.com/
 [xcode]: https://developer.apple.com/xcode/
+[xcodes]: https://github.com/XcodesOrg/XcodesApp
 
 ### Android
 

--- a/mac
+++ b/mac
@@ -322,7 +322,7 @@ append_ios_dependencies() {
     cask "figma"
     cask "proxyman"
     cask "sourcetree"
-    mas "XCode", id: 497799835
+    cask "xcodes"
 EOF
 }
 


### PR DESCRIPTION
https://github.com/nimblehq/laptop/issues/48

## What happened

Added Xcodes installation through Homebrew to the iOS dependencies section of the laptop setup script. This provides an easier way to manage multiple Xcode versions.
 
## Insight

- Added `cask "xcodes"` to the iOS dependencies section
- Remove Xcode installation as it should be managed by `Xcodes.app`
- Updated README.
 
## Proof Of Work

- Script tested on M4 Macs running macOS Sequoia 15.1.1


![CleanShot 2568-01-24 at 15 29 30](https://github.com/user-attachments/assets/3161988c-2a68-4ad8-a5e9-0a83a823dc86)

