### PR TITLE
[#50] Fix script fails to install and add container/Node.js manager options

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,6 @@ Applications:
 - [Google Chrome] as the default browser
 - [Keybase] to have encrypted team communication
 - [Postman] a collaboration platform for API development
-- [Skitch] get your point across with fewer words using annotation, shapes and sketches
 - [Slack] for general team communication
 - [VS Code] code editor
 
@@ -55,7 +54,6 @@ Applications:
 [google chrome]: https://www.google.com/chrome/
 [keybase]: https://keybase.io/
 [postman]: https://www.postman.com/
-[skitch]: https://evernote.com/products/skitch
 [slack]: https://www.slack.com/
 [vs code]: https://code.visualstudio.com/
 
@@ -155,11 +153,11 @@ Plugins for asdf:
 
 - [Temurin] OpenJDK from the Adoptium
 - [Android Studio] Android IDE
-- [Android SDK] Software Development Kit for Android
+- [Android Command Line Tools] Command-line tools for Android development
 
 [temurin]: https://adoptium.net
 [android studio]: https://developer.android.com/studio/index.html
-[android sdk]: https://developer.android.com/studio/releases/sdk-tools
+[android command line tools]: https://developer.android.com/studio/command-line
 
 It should take less than 15 minutes to install (depending on your machine and internet speed).
 

--- a/mac
+++ b/mac
@@ -249,7 +249,7 @@ append_general_dependencies() {
     cask "google-chrome" unless File.directory?("/Applications/Google Chrome.app")
     cask "1password" unless File.directory?("/Applications/1Password 7.app")
     cask "1password-cli"
-    cask "skitch" unless File.directory?("/Applications/Skitch.app")
+
     cask "postman" unless File.directory?("/Applications/Postman.app")
     cask "iterm2" unless File.directory?("/Applications/iTerm.app")
 
@@ -333,7 +333,7 @@ append_android_dependencies() {
     # Android
     cask "temurin"
     cask "android-studio"
-    cask "android-sdk"
+    cask "android-commandlinetools"
 EOF
 }
 


### PR DESCRIPTION
Closes #50

## What happened

The install script is broken and cannot complete installation due to deprecated Homebrew packages, asdf v0.18+ breaking changes, and other bugs. Additionally, added Rancher Desktop and nvm as alternative options.

## Insight

### Bug fixes

- **Removed `cask "skitch"`** — Disabled upstream since 2024-06-25, causing install failure
- **Replaced `cask "android-sdk"` with `cask "android-commandlinetools"`** — Google deprecated the standalone SDK tools in favor of `android-commandlinetools`, which includes `sdkmanager` to download SDK packages
- **Removed `tap "homebrew/services"`** — Deprecated and now built into Homebrew
- **Updated asdf commands for v0.18+** — Hyphenated commands (`plugin-list`, `plugin-add`, `plugin-update`, `list-all`) were removed; `global` was replaced with `set --home`
- **Moved `asdf set --home` outside the install-only `if` block** — Previously the version was only set on fresh installs, causing `gem`/`bundle` to fail on re-runs with "No version is set"
- **Fixed Go regex pattern** — Was using Elixir's OTP pattern (`-otp-\d+$`), which matched no Go versions
- **Fixed default version regex** — Escaped dots and used `(\.\d+)?` to properly match stable versions only
- **Added existence check for Oh My Zsh** — The installer fails when `~/.oh-my-zsh` already exists; now skips if already installed

### New features

- **Added Rancher Desktop as an alternative to Docker Desktop** — Docker Desktop requires a paid subscription for companies with more than 250 employees or $10M in revenue. Rancher Desktop is a free, open-source alternative that provides the same container runtime and Kubernetes support
- **Added nvm as an alternative to asdf for Node.js** — nvm is widely adopted in the Node.js community and some projects include `.nvmrc` for version pinning. Providing it as an option gives developers flexibility to use the tool they are already familiar with

## Proof Of Work

N/A