### PR TITLE
[#50] Fix broken install script and add Node.js manager option

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,21 @@ Do you want to install iOS's dependencies? [y|N]
 Do you want to install Android's dependencies? [y|N]
 ```
 
+When installing Web dependencies, additional prompts will appear:
+
+```text
+Select a container tool:
+  1) Docker Desktop
+  2) Rancher Desktop
+  3) Skip
+Enter your choice [1|2|3]
+
+Select a Node.js version manager:
+  1) asdf (nodejs plugin)
+  2) nvm
+Enter your choice [1|2]
+```
+
 ## What it sets up
 
 ### Default
@@ -101,12 +116,13 @@ Utilities:
 
 Tools:
 
-- [Docker] for managing project dependencies
+- [Docker Desktop] or [Rancher Desktop] for container management (user selects during install)
 - [ImageMagick] for cropping and resizing images
 - [Yarn] JavaScript package manager
 - [JetBrains Toolbox] for managing JetBrains tools the easy way
 
-[docker]: https://www.docker.com/community-edition
+[docker desktop]: https://www.docker.com/products/docker-desktop/
+[rancher desktop]: https://rancherdesktop.io/
 [imagemagick]: https://www.imagemagick.org/
 [yarn]: https://yarnpkg.com/
 [jetbrains toolbox]: https://www.jetbrains.com/toolbox-app/
@@ -120,6 +136,13 @@ Command Line Interfaces:
 [heroku cli]: https://toolbelt.heroku.com/
 [aws cli]: https://aws.amazon.com/cli/
 [phrase cli]: https://phrase.com/cli/
+
+Node.js version manager (user selects during install):
+
+- [asdf] nodejs plugin
+- [nvm] Node Version Manager
+
+[nvm]: https://github.com/nvm-sh/nvm
 
 Plugins for asdf:
 

--- a/README.md
+++ b/README.md
@@ -37,15 +37,9 @@ Do you want to install iOS's dependencies? [y|N]
 Do you want to install Android's dependencies? [y|N]
 ```
 
-When installing Web dependencies, additional prompts will appear:
+When installing Web dependencies, an additional prompt will appear:
 
 ```text
-Select a container tool:
-  1) Docker Desktop
-  2) Rancher Desktop
-  3) Skip
-Enter your choice [1|2|3]
-
 Select a Node.js version manager:
   1) asdf (nodejs plugin)
   2) nvm
@@ -116,13 +110,12 @@ Utilities:
 
 Tools:
 
-- [Docker Desktop] or [Rancher Desktop] for container management (user selects during install)
+- [Docker] for managing project dependencies
 - [ImageMagick] for cropping and resizing images
 - [Yarn] JavaScript package manager
 - [JetBrains Toolbox] for managing JetBrains tools the easy way
 
-[docker desktop]: https://www.docker.com/products/docker-desktop/
-[rancher desktop]: https://rancherdesktop.io/
+[docker]: https://www.docker.com/community-edition
 [imagemagick]: https://www.imagemagick.org/
 [yarn]: https://yarnpkg.com/
 [jetbrains toolbox]: https://www.jetbrains.com/toolbox-app/

--- a/README.md
+++ b/README.md
@@ -47,7 +47,6 @@ Applications:
 - [Google Chrome] as the default browser
 - [Keybase] to have encrypted team communication
 - [Postman] a collaboration platform for API development
-- [Skitch] get your point across with fewer words using annotation, shapes and sketches
 - [Slack] for general team communication
 - [VS Code] code editor
 
@@ -55,7 +54,6 @@ Applications:
 [google chrome]: https://www.google.com/chrome/
 [keybase]: https://keybase.io/
 [postman]: https://www.postman.com/
-[skitch]: https://evernote.com/products/skitch
 [slack]: https://www.slack.com/
 [vs code]: https://code.visualstudio.com/
 
@@ -155,11 +153,11 @@ Plugins for asdf:
 
 - [Temurin] OpenJDK from the Adoptium
 - [Android Studio] Android IDE
-- [Android SDK] Software Development Kit for Android
+- [Android Command Line Tools] Command-line tools for Android development
 
 [temurin]: https://adoptium.net
 [android studio]: https://developer.android.com/studio/index.html
-[android sdk]: https://developer.android.com/studio/releases/sdk-tools
+[android command line tools]: https://developer.android.com/studio/command-line
 
 It should take less than 15 minutes to install (depending on your machine and internet speed).
 

--- a/mac
+++ b/mac
@@ -249,7 +249,7 @@ append_general_dependencies() {
     cask "google-chrome" unless File.directory?("/Applications/Google Chrome.app")
     cask "1password" unless File.directory?("/Applications/1Password 7.app")
     cask "1password-cli"
-    cask "skitch" unless File.directory?("/Applications/Skitch.app")
+
     cask "postman" unless File.directory?("/Applications/Postman.app")
     cask "iterm2" unless File.directory?("/Applications/iTerm.app")
 
@@ -333,7 +333,7 @@ append_android_dependencies() {
     # Android
     cask "temurin"
     cask "android-studio"
-    cask "android-sdk"
+    cask "android-commandlinetools"
 EOF
 }
 

--- a/mac
+++ b/mac
@@ -251,6 +251,39 @@ install_asdf_golang() {
   install_asdf_language "golang" "^\d+\.\d+(\.\d+)?$"
 }
 
+install_container_manager() {
+  echo "Select a container tool:"
+  echo "  1) Docker Desktop"
+  echo "  2) Rancher Desktop"
+  echo "  3) Skip"
+  read -r -p "Enter your choice [1|2|3] " container_tool
+  if [[ $container_tool == "1" ]]; then
+    if [ -d "/Applications/Rancher Desktop.app" ]; then
+      fancy_echo "Rancher Desktop is installed. Please uninstall it first before installing Docker Desktop."
+    else
+      brew install --cask docker
+    fi
+  elif [[ $container_tool == "2" ]]; then
+    if [ -d "/Applications/Docker.app" ]; then
+      fancy_echo "Docker Desktop is installed. Please uninstall it first before installing Rancher Desktop."
+    else
+      brew install --cask rancher
+    fi
+  fi
+}
+
+install_node_manager() {
+  echo "Select a Node.js version manager:"
+  echo "  1) asdf (nodejs plugin)"
+  echo "  2) nvm"
+  read -r -p "Enter your choice [1|2] " node_manager
+  if [[ $node_manager == "2" ]]; then
+    install_nvm_nodejs
+  else
+    install_asdf_nodejs
+  fi
+}
+
 append_general_dependencies() {
   fancy_echo "Appending general dependencies to Brewfile"
 
@@ -375,7 +408,6 @@ install_laptop_local() {
 
 install() {
   read -r -p "Do you want to install Web's dependencies? [y|N] " web_dep
-
   read -r -p "Do you want to install iOS's dependencies? [y|N] " ios_dep
   read -r -p "Do you want to install Android's dependencies? [y|N] " android_dep
 
@@ -399,36 +431,11 @@ install() {
   install_dependencies
 
   if [[ $web_dep =~ (y|yes|Y) ]];then
-    echo "Select a container tool:"
-    echo "  1) Docker Desktop"
-    echo "  2) Rancher Desktop"
-    echo "  3) Skip"
-    read -r -p "Enter your choice [1|2|3] " container_tool
-    if [[ $container_tool == "1" ]]; then
-      if [ -d "/Applications/Rancher Desktop.app" ]; then
-        fancy_echo "Rancher Desktop is installed. Please uninstall it first before installing Docker Desktop."
-      else
-        brew install --cask docker
-      fi
-    elif [[ $container_tool == "2" ]]; then
-      if [ -d "/Applications/Docker.app" ]; then
-        fancy_echo "Docker Desktop is installed. Please uninstall it first before installing Rancher Desktop."
-      else
-        brew install --cask rancher
-      fi
-    fi
+    install_container_manager
 
     install_asdf
     install_asdf_ruby
-    echo "Select a Node.js version manager:"
-    echo "  1) asdf (nodejs plugin)"
-    echo "  2) nvm"
-    read -r -p "Enter your choice [1|2] " node_manager
-    if [[ $node_manager == "2" ]]; then
-      install_nvm_nodejs
-    else
-      install_asdf_nodejs
-    fi
+    install_node_manager
     install_asdf_erlang
     install_asdf_elixir
     install_asdf_golang

--- a/mac
+++ b/mac
@@ -251,27 +251,6 @@ install_asdf_golang() {
   install_asdf_language "golang" "^\d+\.\d+(\.\d+)?$"
 }
 
-install_container_manager() {
-  echo "Select a container tool:"
-  echo "  1) Docker Desktop"
-  echo "  2) Rancher Desktop"
-  echo "  3) Skip"
-  read -r -p "Enter your choice [1|2|3] " container_tool
-  if [[ $container_tool == "1" ]]; then
-    if [ -d "/Applications/Rancher Desktop.app" ]; then
-      fancy_echo "Rancher Desktop is installed. Please uninstall it first before installing Docker Desktop."
-    else
-      brew install --cask docker
-    fi
-  elif [[ $container_tool == "2" ]]; then
-    if [ -d "/Applications/Docker.app" ]; then
-      fancy_echo "Docker Desktop is installed. Please uninstall it first before installing Rancher Desktop."
-    else
-      brew install --cask rancher
-    fi
-  fi
-}
-
 install_node_manager() {
   echo "Select a Node.js version manager:"
   echo "  1) asdf (nodejs plugin)"
@@ -348,6 +327,7 @@ append_web_dependencies() {
     tap "phrase/brewed"
 
     # Devops
+    cask "docker"
     brew "heroku"
     brew "awscli"
 
@@ -431,8 +411,6 @@ install() {
   install_dependencies
 
   if [[ $web_dep =~ (y|yes|Y) ]];then
-    install_container_manager
-
     install_asdf
     install_asdf_ruby
     install_node_manager

--- a/mac
+++ b/mac
@@ -79,8 +79,10 @@ config_zsh() {
   if [[ ! $response =~ (n|no|N) ]];then
     sudo chsh -s $(which zsh)
 
-    fancy_echo "Installing Oh my Zsh"
-    sh -c "$(curl -fsSL https://raw.githubusercontent.com/robbyrussell/oh-my-zsh/master/tools/install.sh)" "" --unattended
+    if [ ! -d ~/.oh-my-zsh ]; then
+      fancy_echo "Installing Oh my Zsh"
+      sh -c "$(curl -fsSL https://raw.githubusercontent.com/robbyrussell/oh-my-zsh/master/tools/install.sh)" "" --unattended
+    fi
 
     if [ ! -d ~/.zsh/zsh-defer ]; then
       git clone https://github.com/romkatv/zsh-defer.git ~/.zsh/zsh-defer
@@ -159,10 +161,10 @@ add_or_update_asdf_plugin() {
   local name="$1"
   local url="$2"
 
-  if ! asdf plugin-list | grep -Fq "$name"; then
-    asdf plugin-add "$name" "$url"
+  if ! asdf plugin list | grep -Fq "$name"; then
+    asdf plugin add "$name" "$url"
   else
-    asdf plugin-update "$name"
+    asdf plugin update "$name"
   fi
 }
 
@@ -172,15 +174,15 @@ install_asdf_language() {
   local version
 
   if [ -z "$regex_pattern" ]; then
-    regex_pattern="^\d+.\d+.?\d?$"
+    regex_pattern="^\d+\.\d+(\.\d+)?$"
   fi
 
-  version="$(asdf list-all "$language" | grep -E "$regex_pattern" | tail -1)"
+  version="$(asdf list all "$language" | grep -E "$regex_pattern" | tail -1)"
 
   if ! asdf list "$language" | grep -Fq "$version"; then
     asdf install "$language" "$version"
-    asdf global "$language" "$version"
   fi
+  asdf set --home "$language" "$version"
 }
 
 install_asdf_ruby() {
@@ -202,6 +204,24 @@ install_asdf_nodejs() {
 
   fancy_echo "Installing latest Node ..."
   install_asdf_language "nodejs"
+}
+
+install_nvm_nodejs() {
+  fancy_echo "Installing nvm ..."
+  brew install nvm
+
+  export NVM_DIR="$HOME/.nvm"
+  mkdir -p "$NVM_DIR"
+
+  # shellcheck disable=SC1091
+  . "$(brew --prefix nvm)/nvm.sh"
+
+  fancy_echo "Installing latest Node via nvm ..."
+  nvm install --lts
+  nvm alias default lts/*
+
+  append_to_zshrc 'export NVM_DIR="$HOME/.nvm"'
+  append_to_zshrc '[ -s "$(brew --prefix nvm)/nvm.sh" ] && \. "$(brew --prefix nvm)/nvm.sh"'
 }
 
 install_asdf_erlang() {
@@ -228,7 +248,7 @@ install_asdf_golang() {
   add_or_update_asdf_plugin "golang" "https://github.com/asdf-community/asdf-golang.git"
 
   fancy_echo "Installing latest Go ..."
-  install_asdf_language "golang" "^\d+.\d+.?\d+?-otp-\d+$"
+  install_asdf_language "golang" "^\d+\.\d+(\.\d+)?$"
 }
 
 append_general_dependencies() {
@@ -237,7 +257,6 @@ append_general_dependencies() {
   tee "$HOME/.Brewfile" <<-EOF
     # General
     tap "thoughtbot/formulae"
-    tap "homebrew/services"
     tap "universal-ctags/universal-ctags"
     tap "github/gh"
 
@@ -296,7 +315,6 @@ append_web_dependencies() {
     tap "phrase/brewed"
 
     # Devops
-    cask "docker"
     brew "heroku"
     brew "awscli"
 
@@ -357,6 +375,7 @@ install_laptop_local() {
 
 install() {
   read -r -p "Do you want to install Web's dependencies? [y|N] " web_dep
+
   read -r -p "Do you want to install iOS's dependencies? [y|N] " ios_dep
   read -r -p "Do you want to install Android's dependencies? [y|N] " android_dep
 
@@ -380,9 +399,36 @@ install() {
   install_dependencies
 
   if [[ $web_dep =~ (y|yes|Y) ]];then
+    echo "Select a container tool:"
+    echo "  1) Docker Desktop"
+    echo "  2) Rancher Desktop"
+    echo "  3) Skip"
+    read -r -p "Enter your choice [1|2|3] " container_tool
+    if [[ $container_tool == "1" ]]; then
+      if [ -d "/Applications/Rancher Desktop.app" ]; then
+        fancy_echo "Rancher Desktop is installed. Please uninstall it first before installing Docker Desktop."
+      else
+        brew install --cask docker
+      fi
+    elif [[ $container_tool == "2" ]]; then
+      if [ -d "/Applications/Docker.app" ]; then
+        fancy_echo "Docker Desktop is installed. Please uninstall it first before installing Rancher Desktop."
+      else
+        brew install --cask rancher
+      fi
+    fi
+
     install_asdf
     install_asdf_ruby
-    install_asdf_nodejs
+    echo "Select a Node.js version manager:"
+    echo "  1) asdf (nodejs plugin)"
+    echo "  2) nvm"
+    read -r -p "Enter your choice [1|2] " node_manager
+    if [[ $node_manager == "2" ]]; then
+      install_nvm_nodejs
+    else
+      install_asdf_nodejs
+    fi
     install_asdf_erlang
     install_asdf_elixir
     install_asdf_golang


### PR DESCRIPTION
Closes #50

## What happened

The install script is broken and cannot complete installation due to deprecated Homebrew packages, asdf v0.18+ breaking changes, and other bugs. Additionally, added nvm as an alternative Node.js version manager option.

## Insight

### Bug fixes

- **Removed `cask "skitch"`** — Disabled upstream since 2024-06-25, causing install failure
- **Replaced `cask "android-sdk"` with `cask "android-commandlinetools"`** — Google deprecated the standalone SDK tools in favor of `android-commandlinetools`, which includes `sdkmanager` to download SDK packages
- **Removed `tap "homebrew/services"`** — Deprecated and now built into Homebrew
- **Updated asdf commands for v0.18+** — Hyphenated commands (`plugin-list`, `plugin-add`, `plugin-update`, `list-all`) were removed; `global` was replaced with `set --home`
- **Moved `asdf set --home` outside the install-only `if` block** — Previously the version was only set on fresh installs, causing `gem`/`bundle` to fail on re-runs with "No version is set"
- **Fixed Go regex pattern** — Was using Elixir's OTP pattern (`-otp-\d+$`), which matched no Go versions
- **Fixed default version regex** — Escaped dots and used `(\.\d+)?` to properly match stable versions only
- **Added existence check for Oh My Zsh** — The installer fails when `~/.oh-my-zsh` already exists; now skips if already installed

### Refactoring

- **Extracted `install_node_manager` function** — Separated Node.js version manager selection into its own function for better readability

### New features

- **Added nvm as an alternative to asdf for Node.js** — nvm is widely adopted in the Node.js community and some projects include `.nvmrc` for version pinning. Providing it as an option gives developers flexibility to use the tool they are already familiar with

## Proof Of Work
<img width="758" height="424" alt="Screenshot 2026-03-30 at 15 35 26" src="https://github.com/user-attachments/assets/65465873-9cea-43a4-9e84-963ff9b9b703" />